### PR TITLE
feat: ASDF_CLANG_TOOLS_LINUX_IGNORE_ARCH setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ install & manage versions.
 ## Environment Variables
 
 - `ASDF_CLANG_TOOLS_MACOS_DEQUARANTINE`: set to "1" to automatically de-quarantine binaries. Otherwise, it will interactively ask to do so.
+- `ASDF_CLANG_TOOLS_LINUX_IGNORE_ARCH`: set to "1" to install the `amd64` binary regardless of the host architecture. The [clang-tools](https://github.com/muttleyxd/clang-tools-static-binaries) project does not currently provide `arm64`/`aarch64` Linux binaries. This assumes that you have set up [QEMU User Emulation](https://wiki.debian.org/QemuUserEmulation) (or similar) to run foreign binaries under emulation.
 
 # Acknowledgements
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -4,6 +4,7 @@ set -euo pipefail
 
 # Settings
 ASDF_CLANG_TOOLS_MACOS_DEQUARANTINE=${ASDF_CLANG_TOOLS_MACOS_DEQUARANTINE:-0}
+ASDF_CLANG_TOOLS_LINUX_IGNORE_ARCH=${ASDF_CLANG_TOOLS_LINUX_IGNORE_ARCH:-0}
 
 GH_REPO="muttleyxd/clang-tools-static-binaries"
 PLUGIN_NAME="clang-tools"
@@ -65,17 +66,27 @@ validate_platform() {
     USE_ARCH=amd64
     ;;
   Linux)
-    case $arch in
-    x86_64)
-      USE_KERNEL=linux
+    USE_KERNEL=linux
+    if [ "$ASDF_CLANG_TOOLS_LINUX_IGNORE_ARCH" != 0 ]; then
       USE_ARCH=amd64
-      ;;
-    esac
+      log "ASDF_CLANG_TOOLS_LINUX_IGNORE_ARCH is set - using '$USE_ARCH' binary."
+    else
+      case $arch in
+      x86_64)
+        USE_ARCH=amd64
+        ;;
+      esac
+    fi
     ;;
   esac
 
   if [ -z "${USE_KERNEL}" ] || [ -z "${USE_ARCH}" ]; then
-    fail "Unsupported platform '${kernel}-${arch}'"
+    local msg="Unsupported platform '${kernel}-${arch}'."
+    if [ "$USE_KERNEL" = "linux" ]; then
+      msg="${msg}\n\nSee the 'ASDF_CLANG_TOOLS_LINUX_IGNORE_ARCH' setting."
+    fi
+
+    fail "$msg"
   fi
 
   USE_PLATFORM="${USE_KERNEL}-${USE_ARCH}"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -6,7 +6,6 @@ set -euo pipefail
 ASDF_CLANG_TOOLS_MACOS_DEQUARANTINE=${ASDF_CLANG_TOOLS_MACOS_DEQUARANTINE:-0}
 
 GH_REPO="muttleyxd/clang-tools-static-binaries"
-GH_REPO_URL="https://github.com/${GH_REPO}"
 PLUGIN_NAME="clang-tools"
 USE_KERNEL=
 USE_ARCH=


### PR DESCRIPTION
The [clang-tools](https://github.com/muttleyxd/clang-tools-static-binaries) project does not currently provide `arm64`/`aarch64` Linux binaries. This adds a setting that will use the `amd64` binary on Linux, regardless of your host architecture. This assumes that you have set up [QEMU User Emulation](https://wiki.debian.org/QemuUserEmulation) (or similar) to run foreign binaries under emulation.