### PR TITLE
macOS arm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ install & manage versions.
 ## Environment Variables
 
 - `ASDF_CLANG_TOOLS_MACOS_DEQUARANTINE`: set to "1" to automatically de-quarantine binaries. Otherwise, it will interactively ask to do so.
+- `ASDF_CLANG_TOOLS_MACOS_IGNORE_ARCH`: set to "1" to install the `amd64` binary regardless of the host architecture on Mac OS.
 - `ASDF_CLANG_TOOLS_LINUX_IGNORE_ARCH`: set to "1" to install the `amd64` binary regardless of the host architecture. The [clang-tools](https://github.com/muttleyxd/clang-tools-static-binaries) project does not currently provide `arm64`/`aarch64` Linux binaries. This assumes that you have set up [QEMU User Emulation](https://wiki.debian.org/QemuUserEmulation) (or similar) to run foreign binaries under emulation.
 
 # Acknowledgements

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -63,16 +63,18 @@ validate_platform() {
 
   case $kernel in
   Darwin)
-    USE_KERNEL=macosx
     if [ "$ASDF_CLANG_TOOLS_MACOS_IGNORE_ARCH" != 0 ]; then
+      USE_KERNEL=macosx
       USE_ARCH=amd64
       log "ASDF_CLANG_TOOLS_MACOS_IGNORE_ARCH is set - using '$USE_ARCH' binary."
     else
       case $arch in
       x86_64)
+        USE_KERNEL=macosx
         USE_ARCH=amd64
         ;;
       arm64)
+        USE_KERNEL=macos-arm
         USE_ARCH=arm64
         ;;
       esac

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -4,6 +4,7 @@ set -euo pipefail
 
 # Settings
 ASDF_CLANG_TOOLS_MACOS_DEQUARANTINE=${ASDF_CLANG_TOOLS_MACOS_DEQUARANTINE:-0}
+ASDF_CLANG_TOOLS_MACOS_IGNORE_ARCH=${ASDF_CLANG_TOOLS_MACOS_IGNORE_ARCH:-0}
 ASDF_CLANG_TOOLS_LINUX_IGNORE_ARCH=${ASDF_CLANG_TOOLS_LINUX_IGNORE_ARCH:-0}
 
 GH_REPO="muttleyxd/clang-tools-static-binaries"
@@ -63,7 +64,19 @@ validate_platform() {
   case $kernel in
   Darwin)
     USE_KERNEL=macosx
-    USE_ARCH=amd64
+    if [ "$ASDF_CLANG_TOOLS_MACOS_IGNORE_ARCH" != 0 ]; then
+      USE_ARCH=amd64
+      log "ASDF_CLANG_TOOLS_MACOS_IGNORE_ARCH is set - using '$USE_ARCH' binary."
+    else
+      case $arch in
+      x86_64)
+        USE_ARCH=amd64
+        ;;
+      arm64)
+        USE_ARCH=arm64
+        ;;
+      esac
+    fi
     ;;
   Linux)
     USE_KERNEL=linux
@@ -84,6 +97,8 @@ validate_platform() {
     local msg="Unsupported platform '${kernel}-${arch}'."
     if [ "$USE_KERNEL" = "linux" ]; then
       msg="${msg}\n\nSee the 'ASDF_CLANG_TOOLS_LINUX_IGNORE_ARCH' setting."
+    elif [ "$USE_KERNEL" = "macosx" ]; then
+      msg="${msg}\n\nSee the 'ASDF_CLANG_TOOLS_MACOS_IGNORE_ARCH' setting."
     fi
 
     fail "$msg"


### PR DESCRIPTION
As of today, the clang-tools-static-binaries repo supports macOS arm executables.

https://github.com/muttleyxd/clang-tools-static-binaries/releases/tag/master-796e77c

This adds support for those.

Uses existing convention for Linux to use amd64 binaries on mac too , as an option.