### PR TITLE
Fixes quarantine confirmation prompt

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -201,9 +201,14 @@ install_version() {
         log "$toolname needs to be de-quarantined to run:\n\n"
         echo -e "  xattr -dr com.apple.quarantine \"${asset_path}/${full_tool_cmd}\""
         echo -e -n "\n\nProceed? [y/N] "
-        read -r reply
-        if [[ $reply =~ $YES_REGEX ]]; then
-          ASDF_CLANG_TOOLS_MACOS_DEQUARANTINE=1
+        # Try /dev/tty first (for asdf contexts), fallback to stdin (for tests)
+        reply=""
+        if read -r reply </dev/tty 2>/dev/null || read -r reply; then
+          if [[ $reply =~ $YES_REGEX ]]; then
+            ASDF_CLANG_TOOLS_MACOS_DEQUARANTINE=1
+          else
+            exit 1
+          fi
         else
           exit 1
         fi


### PR DESCRIPTION
# What
Fixes quarantine confirmation prompt

# How
* Read explicitly from /dev/tty when available

# Why
The issue is that read -r reply is running inside a subshell (line 183) and stdin might not be available in that context. In asdf plugin environments, stdin is often closed or redirected.